### PR TITLE
workaround for vrouter-agent crash

### DIFF
--- a/ist.py
+++ b/ist.py
@@ -1534,8 +1534,13 @@ class CLI_vr(CLI_basic):
         self.output_formatters(args, xpath)
 
     def SnhVxLan(self, args):
-        id = str(args.id) or ''
-        path = 'Snh_VxLanReq?vxlan_id=%s' % (id)
+        if (args.id):
+            id = str(args.id) or ''
+        else:
+            id = None
+        path = 'Snh_VxLanReq'
+        if (id):
+            path += '?vxlan_id=%s' % (id)
         xpath = '//VxLanSandeshData'
         self.IST.get(path)
         self.output_formatters(args, xpath)
@@ -1555,8 +1560,13 @@ class CLI_vr(CLI_basic):
 
     def SnhMpls(self, args):
         type = args.type or ''
-        label = str(args.label) or ''
-        path = 'Snh_MplsReq?type=%s&label=%s' % (type, label)
+        if (args.label):
+          label = str(args.label) or ''
+        else:
+          label = None
+        path = 'Snh_MplsReq?type=%s' % (type)
+        if (label):
+          path += '&label=%s' % (label)
         xpath = '//MplsSandeshData'
         self.IST.get(path)
         self.output_formatters(args, xpath)
@@ -1569,11 +1579,16 @@ class CLI_vr(CLI_basic):
         self.output_formatters(args, xpath)
 
     def SnhNhList(self, args):
-        index = str(args.index) or ''
+        if (args.index):
+            index = str(args.index) or ''
+        else:
+            index = None
         type = args.type or ''
         policy = args.policy or ''
-        path = ('Snh_NhListReq?type=%s&nh_index=%s&policy_enabled=%s' %
-                (type, index, policy))
+        path = 'Snh_NhListReq?type=%s' % (type)
+        if (index):
+            path += '&nh_index=%s' % (index) ## always need to be 2nd
+        path += '&policy_enabled=%s' % (policy)
         xpath = '//NhSandeshData'
         default_columns = ['type', 'nh_index', 'policy', 'itf', 'mac', 'vrf',
                            'valid', 'ref_count', 'mc_list']


### PR DESCRIPTION
Hi,
I tried contrail-introspect-cli with recent tungsten-fabric installation.
Mostly it works great :), but I also noticed three commands (vr mpls, vr nh, vr vxlan nh) make vrouter-agent crash with following log.
(seems to caused by empty index value)

For a while, could you merge this workaround?

[root@instance-template-1 contrail-introspect-cli]# ./ist.py --host 10.128.0.24 vr mpls
Introspect Host: 10.128.0.24
Traceback (most recent call last):
  File "./ist.py", line 1960, in <module>
    main()
  File "./ist.py", line 1957, in main
    args.func(args)
  File "./ist.py", line 1561, in SnhMpls
    self.IST.get(path)
  File "./ist.py", line 69, in get
    response = urlopen(url)
  File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python2.7/urllib2.py", line 431, in open
    response = self._open(req, data)
  File "/usr/lib64/python2.7/urllib2.py", line 449, in _open
    '_open', req)
  File "/usr/lib64/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 1244, in http_open
    return self.do_open(httplib.HTTPConnection, req)
  File "/usr/lib64/python2.7/urllib2.py", line 1217, in do_open
    r = h.getresponse(buffering=True)
  File "/usr/lib64/python2.7/httplib.py", line 1113, in getresponse
    response.begin()
  File "/usr/lib64/python2.7/httplib.py", line 444, in begin
    version, status, reason = self._read_status()
  File "/usr/lib64/python2.7/httplib.py", line 408, in _read_status
    raise BadStatusLine(line)
httplib.BadStatusLine: ''
[root@instance-template-1 contrail-introspect-cli]#

[root@instance-template-1 contrail-introspect-cli]# ./ist.py --host 10.128.0.24 vr nh
Introspect Host: 10.128.0.24
Traceback (most recent call last):
  File "./ist.py", line 1960, in <module>
    main()
  File "./ist.py", line 1957, in main
    args.func(args)
  File "./ist.py", line 1581, in SnhNhList
    self.IST.get(path)
  File "./ist.py", line 69, in get
    response = urlopen(url)
  File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python2.7/urllib2.py", line 431, in open
    response = self._open(req, data)
  File "/usr/lib64/python2.7/urllib2.py", line 449, in _open
    '_open', req)
  File "/usr/lib64/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 1244, in http_open
    return self.do_open(httplib.HTTPConnection, req)
  File "/usr/lib64/python2.7/urllib2.py", line 1217, in do_open
    r = h.getresponse(buffering=True)
  File "/usr/lib64/python2.7/httplib.py", line 1113, in getresponse
    response.begin()
  File "/usr/lib64/python2.7/httplib.py", line 444, in begin
    version, status, reason = self._read_status()
  File "/usr/lib64/python2.7/httplib.py", line 408, in _read_status
    raise BadStatusLine(line)
httplib.BadStatusLine: ''
[root@instance-template-1 contrail-introspect-cli]#

[root@instance-template-1 contrail-introspect-cli]# curl '10.128.0.24:8085/Snh_MplsReq?label=""'
curl: (52) Empty reply from server
[root@instance-template-1 contrail-introspect-cli]#

vrouter-agent.log:
2019-04-06 Sat 04:00:55:086.494 UTC  instance-template-5 [Thread 140327621797632, Pid 317]: !!!! ERROR !!!! Task caught fatal exception: bad lexical cast: source type value could not be interpreted as target TaskImpl: 0x93ceb40


Thanks in advance,
///
Tatsuya