### PR TITLE
added an option for https introspect

### DIFF
--- a/ist.py
+++ b/ist.py
@@ -27,6 +27,7 @@ debug = False
 Default_Max_Width = 36
 proxy = None
 token = None
+ssl_enable = False
 
 ServiceMap = {
     "vr": "contrail-vrouter-agent",
@@ -52,6 +53,8 @@ class Introspect:
     def __init__ (self, host, port, filename):
 
         self.host_url = "http://" + host + ":" + str(port) + "/"
+        if (ssl_enable):
+            self.host_url = "https://" + host + ":" + str(port) + "/"
         self.filename = filename
 
     def get (self, path):
@@ -76,7 +79,7 @@ class Introspect:
                     headers['X-Auth-Token'] = token
                 if debug: print("DEBUG: retrieving url " + url)
                 try:
-                    response = requests.get(url,headers=headers)
+                    response = requests.get(url,headers=headers, verify=False)
                     response.raise_for_status()
                 except requests.exceptions.HTTPError:
                     print('The server couldn\'t fulfill the request.')
@@ -2000,6 +2003,10 @@ def main():
     if '--debug' in argv:
         debug = True
 
+    global ssl_enable
+    if '--ssl-enable' in argv:
+        ssl_enable = True
+
     parser = argparse.ArgumentParser(prog='ist',
         description='A script to make Contrail Introspect output CLI friendly.')
     parser.add_argument('--version',  action="store_true",  help="Script version")
@@ -2009,6 +2016,7 @@ def main():
     parser.add_argument('--proxy',    type=str,             help="Introspect proxy URL")
     parser.add_argument('--token',    type=str,             help="Token for introspect proxy requests")
     parser.add_argument('--file',     type=str,             help="Introspect file")
+    parser.add_argument('--ssl-enable',     action="store_true",             help="used when ssl is enabled on intropect url")
 
     roleparsers = parser.add_subparsers()
 


### PR DESCRIPTION
change to ignore ssl certificate error, when https introspect is used.
 - https://github.com/tungstenfabric/tf-specs/blob/master/5.1/tls_support.md#33-introspect-service

```
 - w/o this option

[root@ip-172-31-15-94 ~]# python3 ist.py ctr status
Failed to reach destination
URL: http://127.0.0.1:8083/Snh_SandeshUVECacheReq?tname=NodeStatus
Reason:  ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response',))

[root@ip-172-31-15-94 ~]# python2 ist.py ctr status
Failed to reach destination
URL: http://127.0.0.1:8083/Snh_SandeshUVECacheReq?tname=NodeStatus
('Reason: ', ConnectionError(ProtocolError('Connection aborted.', BadStatusLine("''",)),))
[root@ip-172-31-15-94 ~]#


- w/ this option

[root@ip-172-31-15-94 ~]# python3 ist.py --ssl-enable ctr status
/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:988: InsecureRequestWarning: Unverified HTTPS request is being made to host '127.0.0.1'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
module_id: contrail-control
state: Functional
description
+-----------+-----------+---------------------+--------+----------------------------------+
| type      | name      | server_addrs        | status | description                      |
+-----------+-----------+---------------------+--------+----------------------------------+
| Collector | n/a       |   172.31.15.94:8086 | Up     | Established                      |
| Database  | Cassandra |   172.31.15.94:9041 | Up     | Established Cassandra connection |
| Database  | RabbitMQ  |   172.31.15.94:5673 | Up     | RabbitMQ connection established  |
+-----------+-----------+---------------------+--------+----------------------------------+
[root@ip-172-31-15-94 ~]# 
[root@ip-172-31-15-94 ~]# 
[root@ip-172-31-15-94 ~]# 
[root@ip-172-31-15-94 ~]# python ist.py --ssl-enable ctr status
/usr/lib/python2.7/site-packages/urllib3/connectionpool.py:847: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
module_id: contrail-control
state: Functional
description
+-----------+-----------+---------------------+--------+----------------------------------+
| type      | name      | server_addrs        | status | description                      |
+-----------+-----------+---------------------+--------+----------------------------------+
| Collector | n/a       |   172.31.15.94:8086 | Up     | Established                      |
| Database  | Cassandra |   172.31.15.94:9041 | Up     | Established Cassandra connection |
| Database  | RabbitMQ  |   172.31.15.94:5673 | Up     | RabbitMQ connection established  |
+-----------+-----------+---------------------+--------+----------------------------------+
[root@ip-172-31-15-94 ~]#
```